### PR TITLE
Add explicit cookbook to runit_service

### DIFF
--- a/libraries/berkshelf_api.rb
+++ b/libraries/berkshelf_api.rb
@@ -226,6 +226,7 @@ class Chef
           @service_resource = runit_service 'berkshelf-api' do
             action :enable
             options new_resource: new_resource
+            cookbook 'berkshelf-api'
             sv_timeout 600 # It can be slow while the cache is loading
           end
         end


### PR DESCRIPTION
Add explicit cookbook to runit_service, as this breaks if the berkshelf_api resource is used outside the berkshelf-api cookbook
