### PR TITLE
Fix "too few arguments error" in default_client_key_path

### DIFF
--- a/libraries/berkshelf_api_endpoint.rb
+++ b/libraries/berkshelf_api_endpoint.rb
@@ -52,7 +52,7 @@ class Chef
 
     def default_client_key_path
       uri = URI.parse(url)
-      key_file = "%s_%s_%s.pem" % uri.scheme, uri.host, uri.port
+      key_file = "%s_%s_%s.pem" % [ uri.scheme, uri.host, uri.port ]
       ::File.join(parent.path, key_file)
     end
 


### PR DESCRIPTION
When using % to format a string with multiple substitutions, you must provide an array for vars (at least in 1.9.3).  

Results in this error:

```
ArgumentError
-------------
too few arguments


Cookbook Trace:
---------------
  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/berkshelf-api/libraries/berkshelf_api_endpoint.rb:58:in `%'
  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/berkshelf-api/libraries/berkshelf_api_endpoint.rb:58:in `default_client_key_path'
  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/berkshelf-api/libraries/berkshelf_api_endpoint.rb:53:in `block in <class:BerkshelfApiChefServerEndpoint>'
  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/poise/libraries/lazy_default.rb:38:in `instance_eval'
  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/poise/libraries/lazy_default.rb:38:in `set_or_return'
  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/poise/libraries/lwrp_polyfill.rb:41:in `block in attribute'
  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/zos-ops-subsystem-berkshelf_api/recipes/self-serving.rb:32:in `block (2 levels) in from_file'
  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/poise/libraries/subresources.rb:93:in `instance_exec'
  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/poise/libraries/subresources.rb:93:in `block (2 levels) in method_missing'
  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/poise/libraries/subresources.rb:89:in `block in method_missing'
  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/poise/libraries/subcontext_block.rb:60:in `instance_eval'
  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/poise/libraries/subcontext_block.rb:60:in `subcontext_block'
  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/poise/libraries/subresources.rb:88:in `method_missing'
  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/zos-ops-subsystem-berkshelf_api/recipes/self-serving.rb:28:in `block in from_file'
  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/zos-ops-subsystem-berkshelf_api/recipes/self-serving.rb:19:in `from_file'
  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/zos-ops-subsystem-berkshelf_api/recipes/default.rb:15:in `from_file'
  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/zos-ops-app-chef_artifact_server/recipes/default.rb:28:in `from_file'


Relevant File Content:
----------------------
/tmp/vagrant-chef-1/chef-solo-1/cookbooks/berkshelf-api/libraries/berkshelf_api_endpoint.rb:

 51:      attribute(:client_name, kind_of: String, required: true)
 52:      attribute(:client_key, kind_of: String, required: true)
 53:      attribute(:client_key_path, kind_of: String, default: lazy { default_client_key_path })
 54:
 55:      def default_client_key_path
 56:        uri = URI.parse(url)
 57:        binding.pry # clintoncwolfe added temporarily
 58>>       key_file = "%s_%s_%s.pem" % uri.scheme, uri.host, uri.port
 59:        ::File.join(parent.path, key_file)
 60:      end
 61:
 62:      def endpoint_data
 63:        {
 64:          type: 'chef_server',
 65:          options: {
 66:            url: url,
 67:            client_name: client_name,
```
